### PR TITLE
Cody shows Ollama models in chat by default

### DIFF
--- a/blog/offline-ai-code-assistant/index.md
+++ b/blog/offline-ai-code-assistant/index.md
@@ -30,6 +30,8 @@ Let's have a look at how we can set this up with VS Code for the absolute offlin
     "url": "http://127.0.0.1:11434",
     "model": "llama3:8b"
   },
+  // Enable Ollama for Cody Chat:
+  "cody.experimental.ollamaChat": true,
   // optional but useful to see detailed logs in the OUTPUT tab
   // (make sure to select "Cody by Sourcegraph" from the dropbdown)
   "cody.debug.verbose": true

--- a/blog/offline-ai-code-assistant/index.md
+++ b/blog/offline-ai-code-assistant/index.md
@@ -30,14 +30,6 @@ Let's have a look at how we can set this up with VS Code for the absolute offlin
     "url": "http://127.0.0.1:11434",
     "model": "llama3:8b"
   },
-  // Cody chat configuration:
-  "cody.dev.models": [
-    {
-      "provider": "ollama",
-      "model": "llama3:8b",
-      "apiEndpoint": "http://127.0.0.1:11434"
-    }
-  ],
   // optional but useful to see detailed logs in the OUTPUT tab
   // (make sure to select "Cody by Sourcegraph" from the dropbdown)
   "cody.debug.verbose": true


### PR DESCRIPTION
Awesome post!

No need to use `cody.dev.models` to bring in Ollama models for chat. It shows all available Ollama models by default in the chat model selector. (It doesn't hurt, it's just not needed.)